### PR TITLE
set synmaxcol=120

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -51,6 +51,7 @@ set scrolloff=10
 "" Performance improvements
 set lazyredraw
 set ttyfast
+set synmaxcol=120
 
 "" Do not ring errors
 set noerrorbells


### PR DESCRIPTION
Limit syntax highlighting up to the column 120.

This improves the performance when opening files with large columns,
generally large XML, or logs.