### PR TITLE
Add support for Python 3.6

### DIFF
--- a/syntax/python.vim
+++ b/syntax/python.vim
@@ -186,6 +186,8 @@ else
   syn match   pythonStatement   "\<async\s\+for\>" display
 endif
 
+syn cluster pythonExpression contains=pythonStatement,pythonRepeat,pythonConditional,pythonOperator,pythonNumber,pythonHexNumber,pythonOctNumber,pythonBinNumber,pythonFloat,pythonString,pythonBytes,pythonBoolean,pythonBuiltinObj,pythonBuiltinFunc
+
 "
 " Decorators (new in Python 2.4)
 "
@@ -276,6 +278,11 @@ else
   syn region pythonString   start=+"+ skip=+\\\\\|\\"\|\\$+ excludenl end=+"+ end=+$+ keepend contains=pythonBytesEscape,pythonBytesEscapeError,pythonUniEscape,pythonUniEscapeError,@Spell
   syn region pythonString   start=+"""+ end=+"""+ keepend contains=pythonBytesEscape,pythonBytesEscapeError,pythonUniEscape,pythonUniEscapeError,pythonDocTest2,pythonSpaceError,@Spell
   syn region pythonString   start=+'''+ end=+'''+ keepend contains=pythonBytesEscape,pythonBytesEscapeError,pythonUniEscape,pythonUniEscapeError,pythonDocTest,pythonSpaceError,@Spell
+
+  syn region pythonFString   start=+[fF]'+ skip=+\\\\\|\\'\|\\$+ excludenl end=+'+ end=+$+ keepend contains=pythonBytesEscape,pythonBytesEscapeError,pythonUniEscape,pythonUniEscapeError,@Spell
+  syn region pythonFString   start=+[fF]"+ skip=+\\\\\|\\"\|\\$+ excludenl end=+"+ end=+$+ keepend contains=pythonBytesEscape,pythonBytesEscapeError,pythonUniEscape,pythonUniEscapeError,@Spell
+  syn region pythonFString   start=+[fF]"""+ end=+"""+ keepend contains=pythonBytesEscape,pythonBytesEscapeError,pythonUniEscape,pythonUniEscapeError,pythonDocTest2,pythonSpaceError,@Spell
+  syn region pythonFString   start=+[fF]'''+ end=+'''+ keepend contains=pythonBytesEscape,pythonBytesEscapeError,pythonUniEscape,pythonUniEscapeError,pythonDocTest,pythonSpaceError,@Spell
 endif
 
 if s:Python2Syntax()
@@ -326,8 +333,9 @@ if s:Enabled("g:python_highlight_string_format")
     syn match pythonStrFormat "{{\|}}" contained containedin=pythonString,pythonUniString,pythonUniRawString,pythonRawString
     syn match pythonStrFormat	"{\%(\%([^[:cntrl:][:space:][:punct:][:digit:]]\|_\)\%([^[:cntrl:][:punct:][:space:]]\|_\)*\|\d\+\)\=\%(\.\%([^[:cntrl:][:space:][:punct:][:digit:]]\|_\)\%([^[:cntrl:][:punct:][:space:]]\|_\)*\|\[\%(\d\+\|[^!:\}]\+\)\]\)*\%(![rsa]\)\=\%(:\%({\%(\%([^[:cntrl:][:space:][:punct:][:digit:]]\|_\)\%([^[:cntrl:][:punct:][:space:]]\|_\)*\|\d\+\)}\|\%([^}]\=[<>=^]\)\=[ +-]\=#\=0\=\d*,\=\%(\.\d\+\)\=[bcdeEfFgGnosxX%]\=\)\=\)\=}" contained containedin=pythonString,pythonUniString,pythonUniRawString,pythonRawString
   else
-    syn match pythonStrFormat "{{\|}}" contained containedin=pythonString,pythonRawString
-    syn match pythonStrFormat	"{\%(\%([^[:cntrl:][:space:][:punct:][:digit:]]\|_\)\%([^[:cntrl:][:punct:][:space:]]\|_\)*\|\d\+\)\=\%(\.\%([^[:cntrl:][:space:][:punct:][:digit:]]\|_\)\%([^[:cntrl:][:punct:][:space:]]\|_\)*\|\[\%(\d\+\|[^!:\}]\+\)\]\)*\%(![rsa]\)\=\%(:\%({\%(\%([^[:cntrl:][:space:][:punct:][:digit:]]\|_\)\%([^[:cntrl:][:punct:][:space:]]\|_\)*\|\d\+\)}\|\%([^}]\=[<>=^]\)\=[ +-]\=#\=0\=\d*,\=\%(\.\d\+\)\=[bcdeEfFgGnosxX%]\=\)\=\)\=}" contained containedin=pythonString,pythonRawString
+    syn match pythonStrFormat "{{\|}}" contained containedin=pythonString,pythonRawString,pythonFString
+    syn match pythonStrFormat "{\%(\%([^[:cntrl:][:space:][:punct:][:digit:]]\|_\)\%([^[:cntrl:][:punct:][:space:]]\|_\)*\|\d\+\)\=\%(\.\%([^[:cntrl:][:space:][:punct:][:digit:]]\|_\)\%([^[:cntrl:][:punct:][:space:]]\|_\)*\|\[\%(\d\+\|[^!:\}]\+\)\]\)*\%(![rsa]\)\=\%(:\%({\%(\%([^[:cntrl:][:space:][:punct:][:digit:]]\|_\)\%([^[:cntrl:][:punct:][:space:]]\|_\)*\|\d\+\)}\|\%([^}]\=[<>=^]\)\=[ +-]\=#\=0\=\d*,\=\%(\.\d\+\)\=[bcdeEfFgGnosxX%]\=\)\=\)\=}" contained containedin=pythonString,pythonRawString
+    syn region pythonStrInterpRegion start="{"he=e+1,rs=e+1 end="\%(![rsa]\)\=\%(:\%({\%(\%([^[:cntrl:][:space:][:punct:][:digit:]]\|_\)\%([^[:cntrl:][:punct:][:space:]]\|_\)*\|\d\+\)}\|\%([^}]\=[<>=^]\)\=[ +-]\=#\=0\=\d*,\=\%(\.\d\+\)\=[bcdeEfFgGnosxX%]\=\)\=\)\=}"hs=s-1,re=s-1 extend contained containedin=pythonFString contains=pythonStrInterpRegion,@pythonExpression
   endif
 endif
 
@@ -370,28 +378,34 @@ if s:Python2Syntax()
 
   syn match   pythonOctError	"\<0[oO]\=\o*[8-9]\d*[lL]\=\>" display
   syn match   pythonBinError	"\<0[bB][01]*[2-9]\d*[lL]\=\>" display
+
+  syn match   pythonFloat	"\.\d\+\%([eE][+-]\=\d\+\)\=[jJ]\=\>" display
+  syn match   pythonFloat	"\<\d\+[eE][+-]\=\d\+[jJ]\=\>" display
+  syn match   pythonFloat	"\<\d\+\.\d*\%([eE][+-]\=\d\+\)\=[jJ]\=" display
 else
   syn match   pythonHexError	"\<0[xX]\x*[g-zG-Z]\x*\>" display
   syn match   pythonOctError	"\<0[oO]\=\o*\D\+\d*\>" display
   syn match   pythonBinError	"\<0[bB][01]*\D\+\d*\>" display
 
-  syn match   pythonHexNumber	"\<0[xX]\x\+\>" display
-  syn match   pythonOctNumber "\<0[oO]\o\+\>" display
-  syn match   pythonBinNumber "\<0[bB][01]\+\>" display
+  syn match   pythonHexNumber	"\<0[xX][_0-9a-fA-F]*\x\>" display
+  syn match   pythonOctNumber "\<0[oO][_0-7]*\o\>" display
+  syn match   pythonBinNumber "\<0[bB][_01]*[01]\>" display
 
-  syn match   pythonNumberError	"\<\d\+\D\>" display
-  syn match   pythonNumberError	"\<0\d\+\>" display
+  syn match   pythonNumberError	"\<\d[_0-9]*\D\>" display
+  syn match   pythonNumberError	"\<0[_0-9]\+\>" display
+  syn match   pythonNumberError	"\<\d[_0-9]*_\>" display
   syn match   pythonNumber	"\<\d\>" display
-  syn match   pythonNumber	"\<[1-9]\d\+\>" display
-  syn match   pythonNumber	"\<\d\+[jJ]\>" display
+  syn match   pythonNumber	"\<[1-9][_0-9]*\d\>" display
+  syn match   pythonNumber	"\<\d[jJ]\>" display
+  syn match   pythonNumber	"\<[1-9][_0-9]*\d[jJ]\>" display
 
   syn match   pythonOctError	"\<0[oO]\=\o*[8-9]\d*\>" display
   syn match   pythonBinError	"\<0[bB][01]*[2-9]\d*\>" display
-endif
 
-syn match   pythonFloat		"\.\d\+\%([eE][+-]\=\d\+\)\=[jJ]\=\>" display
-syn match   pythonFloat		"\<\d\+[eE][+-]\=\d\+[jJ]\=\>" display
-syn match   pythonFloat		"\<\d\+\.\d*\%([eE][+-]\=\d\+\)\=[jJ]\=" display
+  syn match   pythonFloat	"\.\d\%([_0-9]*\d\)\=\%([eE][+-]\=\d\%([_0-9]*\d\)\=\)\=[jJ]\=\>" display
+  syn match   pythonFloat	"\<\d\%([_0-9]*\d\)\=[eE][+-]\=\d\%([_0-9]*\d\)\=[jJ]\=\>" display
+  syn match   pythonFloat	"\<\d\%([_0-9]*\d\)\=\.\d\%([_0-9]*\d\)\=\%([eE][+-]\=\d\%([_0-9]*\d\)\=\)\=[jJ]\=" display
+endif
 
 "
 " Builtin objects and types
@@ -540,6 +554,8 @@ if version >= 508 || !exists("did_python_syn_inits")
     HiLink pythonBytesError         Error
     HiLink pythonBytesEscape        Special
     HiLink pythonBytesEscapeError   Error
+    HiLink pythonFString            String
+    HiLink pythonStrInterpRegion    Special
   endif
 
   HiLink pythonStrFormatting    Special


### PR DESCRIPTION
## Checklist

- ✅  Documentation updated n/a

- ✅  Capture attached (only applicable if there are changes in colour scheme
  and syntax files).
![screenshot from 2017-05-20 21-32-18](https://cloud.githubusercontent.com/assets/1331988/26278820/e7471948-3da3-11e7-9b93-730a4abbbd7d.png)


## Abstract
Adapt syntax highlighting to new changes in Python 3.6.

New version of the syntax file correspond to the one of the fork with
changes applied from another PR. See
https://github.com/rmariano/python-syntax/commit/2d4fccd806721c0ea93e11efe862b5ae24b947de

Fixes https://github.com/rmariano/vim-config/issues/22