### PR TITLE
Format with black

### DIFF
--- a/after/ftplugin/python.vim
+++ b/after/ftplugin/python.vim
@@ -5,7 +5,11 @@ nnoremap <buffer> <localleader>c I# <ESC>
 
 function! AutofixPy()
     echom "Correcting Python file"
-    if executable("autopep8")
+    if executable("black")
+        echom "Calling black"
+        execute ":silent %!black -l79 - 2> /dev/null"
+    elseif executable("autopep8")
+        echom "Calling autopep8"
         execute ":silent %!autopep8 - 2> /dev/null"
     endif
     if executable("isort")

--- a/after/ftplugin/python.vim
+++ b/after/ftplugin/python.vim
@@ -5,15 +5,16 @@ nnoremap <buffer> <localleader>c I# <ESC>
 
 function! AutofixPy()
     echom "Correcting Python file"
+    if executable("isort")
+        echom "Sorting imports"
+        execute ":silent %!isort - 2>/dev/null"
+    endif
     if executable("black")
         echom "Calling black"
         execute ":silent %!black -l79 - 2> /dev/null"
     elseif executable("autopep8")
         echom "Calling autopep8"
         execute ":silent %!autopep8 - 2> /dev/null"
-    endif
-    if executable("isort")
-        execute ":silent %!isort - 2>/dev/null"
     endif
     call Flake8()
 endfunction


### PR DESCRIPTION
## Checklist

- [X] Documentation updated: n/a
- [X] Capture attached (only applicable if there are changes in colour scheme
  and syntax files). n/a

## Abstract
Run first isort, then format the Python file.
Try to format by using ``black`` first, then, ``autopep8``