### PR TITLE
Use ruff to format Python files

### DIFF
--- a/after/ftplugin/python.vim
+++ b/after/ftplugin/python.vim
@@ -8,15 +8,8 @@ vnoremap <leader>u :s/^#//g<CR>:let @/ = ""<CR>
 
 "" Adjust file
 function! AutofixPy()
-    echom "Correcting Python file"
-    if executable("black")
-        echom printf("Formatting with black (margin at %d columns)", &textwidth)
-        execute printf(":silent %%!black -l %d - 2> /dev/null", &textwidth)
-    elseif executable("autopep8")
-        echom "Calling autopep8"
-        execute ":silent %!autopep8 - 2> /dev/null"
-    endif
-    call Flake8()
+    echom "Formatting Python file"
+    execute ":silent %!python3 -m ruff format - 2> /dev/null"
 endfunction
 
 map <F3> :call AutofixPy()<CR>


### PR DESCRIPTION
Requires ruff to be installed, either in the current virtual environment, or at the user level

```bash
python3 -m pip install --user ruff
```